### PR TITLE
Revise http

### DIFF
--- a/src/Plugins/bitcoin.cpp
+++ b/src/Plugins/bitcoin.cpp
@@ -19,12 +19,7 @@ class BitcoinCommand : protected IRC::CommandInterface {
 
 	void run(const IRC::Packet& p) {
 		try {
-			std::string response = "";
-			MyHTTP::get("http://api.coindesk.com/v1/bpi/currentprice.json", response);
-
-			std::cout << response << '\n';
-
-			nlohmann::json data = nlohmann::json::parse(response);
+			nlohmann::json data = nlohmann::json::parse(MyHTTP::get("http://api.coindesk.com/v1/bpi/currentprice.json"));
 
 			p.reply("$" + data["bpi"]["USD"]["rate"].get<std::string>() + " as of: " + data["time"]["updated"].get<std::string>());
 

--- a/src/Plugins/currency.cpp
+++ b/src/Plugins/currency.cpp
@@ -36,12 +36,9 @@ class CurrencyCommand : protected IRC::CommandInterface {
 				return;
 
 			std::string api_query = "https://api.fixer.io/latest?base=" + base + "&symbols=" + others;
+			nlohmann::json result = nlohmann::json::parse(MyHTTP::get(api_query));
 
-			std::string response = "";
-			MyHTTP::get(api_query, response);
-			nlohmann::json result = nlohmann::json::parse(response);
-
-			response = "As of " + result["date"].get<std::string>() + ", 1.00 " + result["base"].get<std::string>()
+			std::string response = "As of " + result["date"].get<std::string>() + ", 1.00 " + result["base"].get<std::string>()
 						+ " will get you: ";
 
 			std::stringstream ss;

--- a/src/Plugins/iplookup.cpp
+++ b/src/Plugins/iplookup.cpp
@@ -23,15 +23,10 @@ class IPLookupCommand : protected IRC::CommandInterface {
 };
 
 static void do_lookup_internal(const std::string& host, nlohmann::json& result) {
-	std::string response = "";
-	if ( !MyHTTP::get("http://freegeoip.net/json/" + host, response) ) {
-		return;
-	}
-
 	try {
-		result = nlohmann::json::parse(response);
-	} catch (...) {
-		std::cerr << "Couldn't parse: " << response << '\n';
+		result = nlohmann::json::parse(MyHTTP::get("http://freegeoip.net/json/" + host));
+	} catch (std::exception& e) {
+		std::cerr << "IPLookup Failure in do_lookup_internal: " << e.what() << '\n';
 	}
 }
 

--- a/src/Plugins/quotes.cpp
+++ b/src/Plugins/quotes.cpp
@@ -27,13 +27,8 @@ class QuoteCommand : protected IRC::CommandInterface {
 static std::string get_random_quote(void) {
 
 	try {
-		std::string response = "";
-		MyHTTP::get("https://favqs.com/api/qotd", response);
-
-		nlohmann::json data = nlohmann::json::parse(response);
-
+		nlohmann::json data = nlohmann::json::parse(MyHTTP::get("https://favqs.com/api/qotd"));
 		return data["quote"]["body"].get<std::string>() + " -- " + data["quote"]["author"].get<std::string>();
-
 	} catch (std::exception& e) {
 		std::cerr << "Failed in get_random_quote(): " << e.what() << '\n';
 	}

--- a/src/Plugins/stocks.cpp
+++ b/src/Plugins/stocks.cpp
@@ -29,9 +29,8 @@ class StocksCommand : protected IRC::CommandInterface {
 
 static std::string get_stock_summary(const std::string& q) {
 	try {
-		std::string response = "";
-
-		MyHTTP::get("https://www.google.com/finance/info?q=" + MyHTTP::uri_encode(q.substr(0, q.find(" ")) ), response);
+		std::string response = MyHTTP::get("https://www.google.com/finance/info?q=" +
+		                                   MyHTTP::uri_encode(q.substr(0, q.find(" ")) ));
 
 		response.erase(0, 5); // erase first five characters.
 		response.erase(response.length()-2); // and last two characters.

--- a/src/Plugins/url-shortener.cpp
+++ b/src/Plugins/url-shortener.cpp
@@ -21,10 +21,10 @@ namespace ShortenURL {
 			                  + ENVIRONMENT["tinyurl"]["api_key"].get<std::string>()
 							  + "&url=" + MyHTTP::uri_encode(long_url);
 
-			MyHTTP::get(url, response);
+			response = MyHTTP::get(url);
 		} catch (std::exception& e) {
 			std::cerr << "Failed to shorten the URL " << long_url << " because: " << e.what() << '\n';
-			response = ""; // just in case.
+			response = "";
 		}
 
 		return response;

--- a/src/Plugins/weather.cpp
+++ b/src/Plugins/weather.cpp
@@ -26,19 +26,13 @@ class WeatherCommand : protected IRC::CommandInterface {
 		query = MyHTTP::uri_encode(query);
 
 		try {
-			std::string search_response = "";
-			MyHTTP::get( "http://autocomplete.wunderground.com/aq?query=" + query , search_response );
-
-			nlohmann::json result = nlohmann::json::parse(search_response);
+			nlohmann::json result = nlohmann::json::parse(MyHTTP::get( "http://autocomplete.wunderground.com/aq?query=" + query));
 			result = result["RESULTS"].at(0);
 
 			std::string lat_long = result["lat"].get<std::string>() + "," + result["lon"].get<std::string>();
 
-			search_response = "";
 			std::string url = "http://api.wunderground.com/api/" + ENVIRONMENT["WUNDERGROUND_KEY"].get<std::string>() + "/geolookup/q/" + lat_long + ".json";
-
-			MyHTTP::get( url , search_response );
-			result = nlohmann::json::parse(search_response);
+			result = nlohmann::json::parse(MyHTTP::get( url ));
 
 			std::string locale = result["location"]["country"].get<std::string>() == "US" ?
 									result["location"]["state"].get<std::string>() : result["location"]["country"].get<std::string>();
@@ -48,11 +42,8 @@ class WeatherCommand : protected IRC::CommandInterface {
 				 if (c == ' ')
 				 	c = '_';
 
-			search_response = "";
-			MyHTTP::get( "http://api.wunderground.com/api/" + ENVIRONMENT["WUNDERGROUND_KEY"].get<std::string>() + "/conditions/q/" + locale + "/" + city + ".json",
-							search_response );
-			result = nlohmann::json::parse(search_response);
-			result = result["current_observation"];
+			url = "http://api.wunderground.com/api/" + ENVIRONMENT["WUNDERGROUND_KEY"].get<std::string>() + "/conditions/q/" + locale + "/" + city + ".json";
+			result = nlohmann::json::parse(MyHTTP::get( url ))["current_observation"];
 
 			std::string weather_result = "Weather for " + result["display_location"]["full"].get<std::string>()
 								+ ": " + result["weather"].get<std::string>() + ", " + result["temperature_string"].get<std::string>()


### PR DESCRIPTION
Change `MyHTTP::get` and `MyHTTP::post` calls to return the response string rather than have the response stored within some `std::string` passed to the function...

```c++
std::string response = "";
MyHTTP::get(url, response);
```
becomes...
```c++
std::string response = MyHTTP::get(url);
```

The functions will now `throw` `std::runtime_error`s if the GET/POST fails.